### PR TITLE
Add Mobile Support

### DIFF
--- a/src/garminsleepshare.user.js
+++ b/src/garminsleepshare.user.js
@@ -123,7 +123,6 @@
       const graphImage = new Image();
       graphImage.src = graphUrl;
       await graphImage.decode();
-      console.log(graphImage.naturalWidth, graphImage.naturalHeight);
       
       ctx.drawImage(graphImage, 81, 195, graphImage.naturalWidth - 162, 25, 45, 575, 579, 25);
 

--- a/src/garminsleepshare.user.js
+++ b/src/garminsleepshare.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Garmin Sleep Share
 // @namespace    https://fxzfun.com/
-// @version      0.9.3
+// @version      0.9.4
 // @description  Share your sleep score as a single photo instead of multiple screenshots of the app
 // @author       FXZFun, Dubster
 // @match        https://connect.garmin.com/*
@@ -123,14 +123,9 @@
       const graphImage = new Image();
       graphImage.src = graphUrl;
       await graphImage.decode();
+      console.log(graphImage.naturalWidth, graphImage.naturalHeight);
       
-      const sleepGraphCanvas = document.createElement('canvas');
-      sleepGraphCanvas.width = 579;
-      sleepGraphCanvas.height = 25;
-      const sleepGraphContext = sleepGraphCanvas.getContext('2d');
-      sleepGraphContext.drawImage(graphImage, -81, -195);
-      
-      ctx.drawImage(sleepGraphCanvas, 45, 575);
+      ctx.drawImage(graphImage, 81, 195, graphImage.naturalWidth - 162, 25, 45, 575, 579, 25);
 
       return await new Promise(resolve => canvas.toBlob(resolve, "image/png"));
    }


### PR DESCRIPTION
This version of the script makes it work on a mobile browser.

**Changes**
 - No longer creates an extra canvas to crop the graph
 - Stretches the graph to the right size so it isn't too small on mobile

