### PR TITLE
Fix issue with string template names

### DIFF
--- a/src/garminsleepshare.user.js
+++ b/src/garminsleepshare.user.js
@@ -158,6 +158,7 @@
       return new Promise((resolve) => {
          function _resolveElements() {
             const elements = document.querySelectorAll(selector);
+            elements = [...elements].filter(e => !e.innerText.includes('_'));
             if (elements.length > 0) {
                clearInterval(interval);
                resolve(elements);

--- a/src/garminsleepshare.user.js
+++ b/src/garminsleepshare.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Garmin Sleep Share
 // @namespace    https://fxzfun.com/
-// @version      0.9.8
+// @version      0.9.9
 // @description  Share your sleep score as a single photo instead of multiple screenshots of the app
 // @author       FXZFun, Dubster
 // @match        https://connect.garmin.com/*

--- a/src/garminsleepshare.user.js
+++ b/src/garminsleepshare.user.js
@@ -157,8 +157,7 @@
    const getElementsAsync = async (selector) => {
       return new Promise((resolve) => {
          function _resolveElements() {
-            const elements = document.querySelectorAll(selector);
-            elements = [...elements].filter(e => !e.innerText.includes('_'));
+            const elements = [...document.querySelectorAll(selector)].filter(e => !e.innerText?.includes('_'));
             if (elements.length > 0) {
                clearInterval(interval);
                resolve(elements);


### PR DESCRIPTION
The script was returning the elements before the strings had loaded, resulting in some images containing code names with underscores